### PR TITLE
Fix cpcs

### DIFF
--- a/.github/workflows/cpcs.yml
+++ b/.github/workflows/cpcs.yml
@@ -19,7 +19,7 @@ jobs:
               <file>.</file>
               ' phpcs.xml
             sed -i '/MY_DOMAIN/ s//fx-builder/' phpcs.xml
-            mv phpcs.xml phpcs.xml.dist
+            cp phpcs.xml phpcs.xml.dist
         - name: CPCS checks
           uses: 10up/wpcs-action@stable
           with:

--- a/.github/workflows/cpcs.yml
+++ b/.github/workflows/cpcs.yml
@@ -14,7 +14,7 @@ jobs:
         - uses: actions/checkout@v4
         - name: CPCS get rules
           run: |
-            wget https://raw.githubusercontent.com/ClassicPress/ClassicPress-Coding-Standards/main/phpcs.xml
+            wget -O phpcs.xml https://raw.githubusercontent.com/ClassicPress/ClassicPress-Coding-Standards/main/phpcs.xml
             sed -i '/^\t<!-- start config -->.*/a\
               <file>.</file>
               ' phpcs.xml


### PR DESCRIPTION
When running `cpcs.yml` workflow `phpcs.xml` in your repo is used instead of the one used in ClassicPress directory.
This PR will overwrite the file just for the workflow, so you'll get the right annotations.