### PR TITLE
Add [sticky] shortcode for highlighted content blocks with aspect ratio support

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -425,19 +425,20 @@ add_shortcode(
         }
 
         $style_parts = [
-            '--fxb-sticky-bg:' . $bg_color,
-            '--fxb-sticky-color:' . $text_color,
-            '--fxb-sticky-padding:' . $padding,
-            '--fxb-sticky-rotate:' . $rotate,
-            '--fxb-sticky-radius:' . $border_radius,
-            '--fxb-sticky-aspect:' . $aspect_ratio,
-            'background:' . $bg_color,
-            'color:' . $text_color,
-            'padding:' . $padding,
-            'border-radius:' . $border_radius,
-            'transform:rotate(' . $rotate . ')',
-            'aspect-ratio:' . $aspect_ratio,
-        ];
+    'box-sizing:border-box',           // <-- ensure padding is counted
+    '--fxb-sticky-bg:' . $bg_color,
+    '--fxb-sticky-color:' . $text_color,
+    '--fxb-sticky-padding:' . $padding,
+    '--fxb-sticky-rotate:' . $rotate,
+    '--fxb-sticky-radius:' . $border_radius,
+    '--fxb-sticky-aspect:' . $aspect_ratio,
+    'background:' . $bg_color,
+    'color:' . $text_color,
+    'padding:' . $padding,
+    'border-radius:' . $border_radius,
+    'transform:rotate(' . $rotate . ')',
+    'aspect-ratio:' . $aspect_ratio,
+];
 
         $classes = 'fxb-sticky';
         if ( $has_shadow ) {

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -355,6 +355,7 @@ add_shortcode(
          * - rotate: Rotation (e.g. -2deg, default: -2deg)
          * - border-radius: Border radius (default: 6px)
          * - shadow: Enable shadow (0/1, default: 1)
+         * - aspect-ratio: Aspect ratio (e.g. 1/1, default: 1/1)
          */
         $atts = is_array( $atts ) ? $atts : [];
 
@@ -363,6 +364,7 @@ add_shortcode(
             'bg_color'      => 'bg-color',
             'text_color'    => 'text-color',
             'border_radius' => 'border-radius',
+            'aspect_ratio'  => 'aspect-ratio',
         ];
         foreach ( $alias_map as $from => $to ) {
             if ( isset( $atts[ $from ] ) && ! isset( $atts[ $to ] ) ) {
@@ -378,6 +380,7 @@ add_shortcode(
                 'rotate'        => '-2deg',
                 'border-radius' => '6px',
                 'shadow'        => '1',
+                'aspect-ratio'  => '1/1',
             ],
             $atts,
             'sticky'
@@ -401,6 +404,11 @@ add_shortcode(
             $border_radius = '6px';
         }
 
+        $aspect_ratio = trim( (string) $atts['aspect-ratio'] );
+        if ( ! preg_match( '/^\d+\/\d+$/', $aspect_ratio ) ) {
+            $aspect_ratio = '1/1';
+        }
+
         $shadow = strtolower( trim( (string) $atts['shadow'] ) );
         $has_shadow = in_array( $shadow, [ '1', 'true', 'yes', 'on' ], true );
 
@@ -422,11 +430,13 @@ add_shortcode(
             '--fxb-sticky-padding:' . $padding,
             '--fxb-sticky-rotate:' . $rotate,
             '--fxb-sticky-radius:' . $border_radius,
+            '--fxb-sticky-aspect:' . $aspect_ratio,
             'background:' . $bg_color,
             'color:' . $text_color,
             'padding:' . $padding,
             'border-radius:' . $border_radius,
             'transform:rotate(' . $rotate . ')',
+            'aspect-ratio:' . $aspect_ratio,
         ];
 
         $classes = 'fxb-sticky';
@@ -444,3 +454,4 @@ add_shortcode(
         );
     }
 );
+

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -342,4 +342,105 @@ add_shortcode(
     }
 );
 
+add_shortcode(
+    'sticky',
+    function ( $atts, $content = null ) {
+        static $did_enqueue_css = false;
 
+        /**
+         * [sticky] shortcode parameters:
+         * - bg-color: Background color (hex, default: #fff3cd)
+         * - text-color: Text color (hex, default: #212529)
+         * - padding: Inner padding (default: 1.5em)
+         * - rotate: Rotation (e.g. -2deg, default: -2deg)
+         * - border-radius: Border radius (default: 6px)
+         * - shadow: Enable shadow (0/1, default: 1)
+         */
+        $atts = is_array( $atts ) ? $atts : [];
+
+        // Back-compat aliases
+        $alias_map = [
+            'bg_color'      => 'bg-color',
+            'text_color'    => 'text-color',
+            'border_radius' => 'border-radius',
+        ];
+        foreach ( $alias_map as $from => $to ) {
+            if ( isset( $atts[ $from ] ) && ! isset( $atts[ $to ] ) ) {
+                $atts[ $to ] = $atts[ $from ];
+            }
+        }
+
+        $atts = shortcode_atts(
+            [
+                'bg-color'      => '#fff3cd',
+                'text-color'    => '#212529',
+                'padding'       => '1.5em',
+                'rotate'        => '-2deg',
+                'border-radius' => '6px',
+                'shadow'        => '1',
+            ],
+            $atts,
+            'sticky'
+        );
+
+        $bg_color = sanitize_hex_color( trim( (string) $atts['bg-color'] ) ) ?: '#fff3cd';
+        $text_color = sanitize_hex_color( trim( (string) $atts['text-color'] ) ) ?: '#212529';
+
+        $padding = trim( (string) $atts['padding'] );
+        if ( ! preg_match( '/^(0|\d+(\.\d+)?(px|%|em|rem|vh|vw))( (0|\d+(\.\d+)?(px|%|em|rem|vh|vw))){0,3}$/', $padding ) ) {
+            $padding = '1.5em';
+        }
+
+        $rotate = trim( (string) $atts['rotate'] );
+        if ( ! preg_match( '/^-?\d+(\.\d+)?deg$/', $rotate ) ) {
+            $rotate = '-2deg';
+        }
+
+        $border_radius = trim( (string) $atts['border-radius'] );
+        if ( $border_radius !== '' && ! preg_match( '/^\d+(\.\d+)?(px|%|em|rem)$/', $border_radius ) ) {
+            $border_radius = '6px';
+        }
+
+        $shadow = strtolower( trim( (string) $atts['shadow'] ) );
+        $has_shadow = in_array( $shadow, [ '1', 'true', 'yes', 'on' ], true );
+
+        if ( ! $did_enqueue_css ) {
+            wp_register_style( 'fxb-sticky-shortcode', false, [], FX_BUILDER_VERSION );
+            wp_enqueue_style( 'fxb-sticky-shortcode' );
+            wp_add_inline_style(
+                'fxb-sticky-shortcode',
+                '.fxb-sticky{position:relative;display:block}' .
+                '.fxb-sticky__inner{display:block}' .
+                '.fxb-sticky--shadow{box-shadow:0 10px 20px rgba(0,0,0,.15)}'
+            );
+            $did_enqueue_css = true;
+        }
+
+        $style_parts = [
+            '--fxb-sticky-bg:' . $bg_color,
+            '--fxb-sticky-color:' . $text_color,
+            '--fxb-sticky-padding:' . $padding,
+            '--fxb-sticky-rotate:' . $rotate,
+            '--fxb-sticky-radius:' . $border_radius,
+            'background:' . $bg_color,
+            'color:' . $text_color,
+            'padding:' . $padding,
+            'border-radius:' . $border_radius,
+            'transform:rotate(' . $rotate . ')',
+        ];
+
+        $classes = 'fxb-sticky';
+        if ( $has_shadow ) {
+            $classes .= ' fxb-sticky--shadow';
+        }
+
+        return sprintf(
+            '<div class="%s" style="%s">' .
+                '<div class="fxb-sticky__inner">%s</div>' .
+            '</div>',
+            esc_attr( $classes ),
+            esc_attr( implode( ';', $style_parts ) . ';' ),
+            do_shortcode( shortcode_unautop( $content ?? '' ) )
+        );
+    }
+);


### PR DESCRIPTION
Description

This PR introduces a new [sticky] shortcode that allows users to display content inside a stylized, rotated “sticky note” block. This is particularly useful for highlighting notes, tips, or callouts in content, without requiring custom CSS.

Features
Customizable background color: via bg-color (hex, default #fff3cd)
Customizable text color: via text-color (hex, default #212529)
Inner padding: via padding (default 1.5em)
Rotation: via rotate (e.g., -2deg, default -2deg)
Border radius: via border-radius (default 6px)
Shadow toggle: via shadow (0/1, default 1)
Aspect ratio control: via aspect-ratio (e.g., 1/1, default 1/1)

All attributes are optional and have sensible defaults to ensure the shortcode works out-of-the-box.

Usage
[sticky bg-color="#fff3cd" text-color="#212529" padding="2em" rotate="-3deg" border-radius="8px" shadow="1" aspect-ratio="1/1"]
Your content here
[/sticky]

This generates a rotated, colored block with optional shadow and aspect ratio control. Content inside the shortcode is fully processed, so other shortcodes can be nested.

Notes
Aspect ratio is enforced via inline CSS, ensuring the block remains square or according to the specified ratio.
Defaults are designed to look good with minimal configuration.
Fully sanitized inputs for security and consistency.

This PR adds only the shortcode itself and its inline styles; it does not affect other plugin functionality.